### PR TITLE
Feature/past order delete

### DIFF
--- a/backend/coffeeBean_backend/src/main/java/com/ll/coffeeBean/domain/order/repository/PastOrderRepository.java
+++ b/backend/coffeeBean_backend/src/main/java/com/ll/coffeeBean/domain/order/repository/PastOrderRepository.java
@@ -1,9 +1,12 @@
 package com.ll.coffeeBean.domain.order.repository;
 
 import com.ll.coffeeBean.domain.order.entity.PastOrder;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PastOrderRepository extends JpaRepository<PastOrder, Long> {
     List<PastOrder> findAllByCustomerId(long id);
+
+    List<PastOrder> findByCreateDateBefore(LocalDateTime endDate);
 }

--- a/backend/coffeeBean_backend/src/main/java/com/ll/coffeeBean/domain/order/service/OrderService.java
+++ b/backend/coffeeBean_backend/src/main/java/com/ll/coffeeBean/domain/order/service/OrderService.java
@@ -133,6 +133,9 @@ public class OrderService {
         order.getCustomer().removeOrder(order);
     }
 
+    /**
+     * 3개월이 지난 주문 목록 삭제
+     */
     @Transactional
     public void processPastOrder(PastOrder order) {
         order.getCustomer().removePastOrder(order);

--- a/backend/coffeeBean_backend/src/main/java/com/ll/coffeeBean/domain/order/service/OrderService.java
+++ b/backend/coffeeBean_backend/src/main/java/com/ll/coffeeBean/domain/order/service/OrderService.java
@@ -84,9 +84,20 @@ public class OrderService {
         List<MenuOrder> orders = orderRepository.findByCreateDateGreaterThanEqualAndCreateDateBefore(startDate,
                 endDate);
 
+        // 24시간 동안 쌓인 주문 처리
         for (MenuOrder order : orders) {
             processOrder(order);
         }
+
+        endDate = endDate.minusMonths(3);
+
+        List<PastOrder> pastOrders = pastOrderRepository.findByCreateDateBefore(endDate);
+
+        // 3개월 전까지의 PastOrder 모두 삭제
+        for (PastOrder pastOrder : pastOrders) {
+            processPastOrder(pastOrder);
+        }
+
         System.out.println("\n\n========================");
         System.out.println("End Scheduled!!\n\n");
     }
@@ -101,7 +112,7 @@ public class OrderService {
          * TODO : 작업 처리, 처리된 작업 및 처리 도중 오류 로깅
          */
         int totalPrice = 0;
-//
+
         List<DetailOrder> orders = order.getOrders();
 
         PastOrder pastOrder = PastOrder.builder()
@@ -120,6 +131,11 @@ public class OrderService {
 
         // 모든 작업 처리 후, 기존의 Order DB 모두 삭제
         order.getCustomer().removeOrder(order);
+    }
+
+    @Transactional
+    public void processPastOrder(PastOrder order) {
+        order.getCustomer().removePastOrder(order);
     }
 
     public Optional<MenuOrder> findById(long id) {

--- a/backend/coffeeBean_backend/src/test/java/com/ll/coffeeBean/domain/order/service/OrderServiceTest.java
+++ b/backend/coffeeBean_backend/src/test/java/com/ll/coffeeBean/domain/order/service/OrderServiceTest.java
@@ -15,8 +15,6 @@ import com.ll.coffeeBean.domain.order.repository.PastOrderRepository;
 import com.ll.coffeeBean.domain.siteUser.entity.SiteUser;
 import com.ll.coffeeBean.domain.siteUser.repository.SiteUserRepository;
 import com.ll.coffeeBean.global.jpa.entity.BaseTime;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
 import java.lang.reflect.Field;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -48,9 +46,6 @@ class OrderServiceTest {
 
     @Autowired
     private SiteUserRepository siteUserRepository;
-
-    @PersistenceContext
-    private EntityManager em;
 
     // 현재 Test 에서 Scheduled 를 확인하지 못해서 단순 로직만 확인
     // 실제 환경에서는 스케쥴러가 잘 작동하는 것 확인
@@ -277,7 +272,6 @@ class OrderServiceTest {
 
         // createDate 변경
         PastOrder pastOrder = pastOrderRepository.findAll().get(0);
-        em.detach(pastOrder);
         Field createDateField = BaseTime.class.getDeclaredField("createDate");
         createDateField.setAccessible(true);
         createDateField.set(pastOrder, LocalDateTime.now().minusMonths(1));
@@ -306,7 +300,6 @@ class OrderServiceTest {
 
         // createDate 변경
         PastOrder pastOrder = pastOrderRepository.findAll().get(0);
-        em.detach(pastOrder);
         Field createDateField = BaseTime.class.getDeclaredField("createDate");
         createDateField.setAccessible(true);
         createDateField.set(pastOrder, LocalDateTime.now().minusMonths(3));

--- a/backend/coffeeBean_backend/src/test/java/com/ll/coffeeBean/domain/order/service/OrderServiceTest.java
+++ b/backend/coffeeBean_backend/src/test/java/com/ll/coffeeBean/domain/order/service/OrderServiceTest.java
@@ -287,9 +287,11 @@ class OrderServiceTest {
         orderService.processOrderByScheduled();
 
         // then
+        SiteUser user = siteUserRepository.findById(1L).get();
         assertEquals(pastOrderRepository.count(), 1L);
         assertEquals(detailOrderRepository.count(), 3);
         assertEquals(siteUserRepository.count(), 1L);
+        assertEquals(user.getPastOrders().getFirst().getOrders().getFirst().getName(), "bean1");
     }
 
     @Test
@@ -314,9 +316,11 @@ class OrderServiceTest {
         orderService.processOrderByScheduled();
 
         // then
+        SiteUser user = siteUserRepository.findById(1L).get();
         assertEquals(pastOrderRepository.count(), 0);
         assertEquals(detailOrderRepository.count(), 0);
         assertEquals(siteUserRepository.count(), 1L);
+        assertEquals(user.getPastOrders().size(), 0);
     }
 
     @Test


### PR DESCRIPTION
closes #17 

## 1. processOrderByScheduled() 에서 PastOrder 처리도 함께 진행
- 매일 14시에, 당일 기준 3개월이 지난 PastOrder DB를 모두 정리
- PastOrder 를 삭제할 때, DetailOrder 도 함께 삭제

## 2. Testcase 를 통해 작동 확인
- 3개월 안팎의 PastOrder를 포함하는 테스트케이스를 하나씩 생성
  - 1개는 실패 케이스, 1개는 성공 케이스
- 각각 조건에 맞게 잘 수행되는지 확인